### PR TITLE
Stabilize Hugo module update script

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/GrantBirki/dario v0.0.0-20260224063023-7f1799e34cc7 h1:VnVe8EYAt4eqVGGlklBfF4CKRiEpBgMCZc0Q8kAsybg=
-github.com/GrantBirki/dario v0.0.0-20260224063023-7f1799e34cc7/go.mod h1:s8A8b1QpPglY2oKoL2flTEIX9EIVI56Pkwp35GksM/I=
 github.com/GrantBirki/dario v0.0.0-20260402164309-6be12ba6838d h1:oK8mndkA7pcJqfKLYKmzSbwUXvDkhwZgw5Eln1lnVH4=
 github.com/GrantBirki/dario v0.0.0-20260402164309-6be12ba6838d/go.mod h1:s8A8b1QpPglY2oKoL2flTEIX9EIVI56Pkwp35GksM/I=

--- a/script/update
+++ b/script/update
@@ -1,7 +1,29 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+module_path="github.com/GrantBirki/dario"
+module_ref="main"
+vendor_root="_vendor/github.com/GrantBirki"
+versioned_vendor_dir="$vendor_root/dario@$module_ref"
+canonical_vendor_dir="$vendor_root/dario"
 
 hugo mod clean
+hugo mod get -u "$module_path@$module_ref"
 hugo mod get -u
 hugo mod tidy
+rm -rf _vendor
 hugo mod vendor
+
+if [[ -d "$versioned_vendor_dir" ]]; then
+  rm -rf "$canonical_vendor_dir"
+  mv "$versioned_vendor_dir" "$canonical_vendor_dir"
+fi
+
+if [[ -f _vendor/modules.txt ]]; then
+  modules_tmp="$(mktemp)"
+  sed "s|^# $module_path@$module_ref |# $module_path |" _vendor/modules.txt >"$modules_tmp"
+  mv "$modules_tmp" _vendor/modules.txt
+fi
+
 hugo mod verify


### PR DESCRIPTION
Update `script/update` to follow the stronger Hugo module refresh flow from `log`, including explicit `dario@main` updates, a clean `_vendor` rebuild, and strict shell error handling.

After vendoring, canonicalize `_vendor/github.com/GrantBirki/dario` and `_vendor/modules.txt` so the repo keeps working with offline builds on Hugo `0.148` instead of falling back to `dario@main` network resolution.
