### PR TITLE
Harden dependency automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,25 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 ---
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: "/"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-    schedule:
-      interval: monthly
+- package-ecosystem: github-actions
+  directory: "/"
+  groups:
+    github-actions:
+      patterns:
+      - "*"
+  schedule:
+    interval: monthly
+  cooldown:
+    default-days: 45
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: monthly
+  cooldown:
+    default-days: 45
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: monthly
+  cooldown:
+    default-days: 45


### PR DESCRIPTION
This pins mutable GitHub Actions references where needed and adds 45-day Dependabot cooldowns for configured dependency ecosystems.